### PR TITLE
[MGBA] Add missing type resources

### DIFF
--- a/NatDexExtension.lua
+++ b/NatDexExtension.lua
@@ -212,6 +212,10 @@ local function NatDexExtension()
 	-- NAT DEX DATA
 	self.Data = {}
 
+	self.Data.pokeTypesList = {
+		fairy = "Fairy",
+	}
+
 	self.Data.pokeNameList = {
 		[412] = "Turtwig"        , [413] = "Grotle"         , [414] = "Torterra"       , [415] = "Chimchar"       , [416] = "Monferno"       ,
 		[417] = "Infernape"      , [418] = "Piplup"         , [419] = "Prinplup"       , [420] = "Empoleon"       , [421] = "Starly"         ,
@@ -6790,6 +6794,11 @@ local function NatDexExtension()
 	end
 
 	function self.addResources()
+		local pokeTypes = Resources.Game.PokemonTypes
+		for id, name in pairs(self.Data.pokeTypesList) do
+			pokeTypes[id] = name
+		end
+
 		local pokeNames = Resources.Game.PokemonNames
 		for id, name in pairs(self.Data.pokeNameList) do
 			pokeNames[id] = name


### PR DESCRIPTION
MGBA doesn't display types (or anything) with images, but instead uses text. It needs the newly added "fairy" text to exist in the Resources file.

This commit fixes that.

### Before
![image](https://github.com/CyanSMP64/NatDexExtension/assets/4258818/2d9173f1-52ba-47c9-8e4d-f37774a164f2)

### After
![image](https://github.com/CyanSMP64/NatDexExtension/assets/4258818/47b01b8e-35d8-4199-b4c7-c60c9124c3ba)
