### PR TITLE
Fix incorrect supporting version check

### DIFF
--- a/NatDexExtension.lua
+++ b/NatDexExtension.lua
@@ -36,7 +36,7 @@ local function NatDexExtension()
 
 	-- Returns true if the Tracker code supports this Nat. Dex rom hack
 	function self.checkIfTrackerVersionSupported()
-		if GameSettings.RomHackSupport.NatDex then
+		if GameSettings and GameSettings.RomHackSupport and GameSettings.RomHackSupport.NatDex then
 			return true
 		end
 


### PR DESCRIPTION
This check was incorrectly testing older Tracker versions, such that it ALWAYS caused an error on Tracker startup and never properly informed the user they needed to update their Tracker.

This commit fixes that issue.

![Image](https://github.com/CyanSMP64/NatDexExtension/assets/4258818/67bef5ea-dc7b-43a2-9910-dbd95cab1ce5)